### PR TITLE
Add crawl task completion tracking

### DIFF
--- a/core/databases/db_completion_tasks.py
+++ b/core/databases/db_completion_tasks.py
@@ -58,7 +58,7 @@ def db_get_incomplete_completion_tasks(amount: int = 1):
 
 def db_release_executing_tasks(uuid_list: list[str]):
     fields = Query()
-    db.update({"executing": False}, fields.uuid.any(uuid_list))
+    db.update({"executing": False}, fields.uuid.one_of(uuid_list))
 
 
 def db_update_completion_task_after_summarizing(summary: str, uuid: str):

--- a/core/databases/db_completion_tasks.py
+++ b/core/databases/db_completion_tasks.py
@@ -57,7 +57,8 @@ def db_get_incomplete_completion_tasks(amount: int = 1):
 
 
 def db_release_executing_tasks(uuid_list: list[str]):
-    pass
+    fields = Query()
+    db.update({"executing": False}, fields.uuid in uuid_list)
 
 
 def db_update_completion_task_after_summarizing(summary: str, uuid: str):

--- a/core/databases/db_completion_tasks.py
+++ b/core/databases/db_completion_tasks.py
@@ -19,6 +19,7 @@ def db_add_completion_task(prompt, mode):
             "completed": False,
             "completion_result": None,
             "executing": False,
+            "required_crawl_tasks": [],  # uuid list that has to be completed first
             "completion_date": 0,
             "execution_date": 0,
             "timestamp": timestamp,
@@ -43,14 +44,20 @@ def db_set_completion_task_executing(uuid: str):
     )
 
 
-def db_get_incomplete_completion_task():
+def db_get_incomplete_completion_tasks(amount: int = 1):
     fields = Query()
 
-    results = db.get(fields.completed == False and fields.executing == False)
-    if results is not None:
-        db_set_completion_task_executing(results["uuid"])
+    results = db.search(fields.completed == False and fields.executing == False)
+    results = results[:amount]
+
+    for task in results:
+        db_set_completion_task_executing(task["uuid"])
 
     return results
+
+
+def db_release_executing_tasks(uuid_list: list[str]):
+    pass
 
 
 def db_update_completion_task_after_summarizing(summary: str, uuid: str):

--- a/core/databases/db_completion_tasks.py
+++ b/core/databases/db_completion_tasks.py
@@ -58,7 +58,7 @@ def db_get_incomplete_completion_tasks(amount: int = 1):
 
 def db_release_executing_tasks(uuid_list: list[str]):
     fields = Query()
-    db.update({"executing": False}, fields.uuid in uuid_list)
+    db.update({"executing": False}, fields.uuid.any(uuid_list))
 
 
 def db_update_completion_task_after_summarizing(summary: str, uuid: str):

--- a/core/databases/db_crawl_tasks.py
+++ b/core/databases/db_crawl_tasks.py
@@ -95,6 +95,15 @@ def db_is_crawl_task_fully_embedded(uuid: str, model_name: str):
     return current_count >= baseline_count
 
 
+def db_are_crawl_tasks_fully_embedded(uuid_list: str, model_name: str):
+    # todo: replace this naive approach with a one-query solution
+    for uuid in uuid_list:
+        if db_is_crawl_task_fully_embedded(uuid, model_name) is False:
+            return False
+
+    return True
+
+
 def db_increment_task_embedding_progression(uuid: str, model_name: str):
     fields = Query()
     task = db.get(fields.uuid == uuid)

--- a/core/databases/db_embeddings.py
+++ b/core/databases/db_embeddings.py
@@ -18,6 +18,10 @@ text_splitter = RecursiveCharacterTextSplitter(
 )
 
 
+def db_get_currently_used_vector_model():
+    return embedder_config.model_name
+
+
 def db_add_text_batch(text: str, db_full_name: str):
     # automatically splits text before embedding it
     chunks = text_splitter.split_text(text)

--- a/core/databases/db_url_pool.py
+++ b/core/databases/db_url_pool.py
@@ -13,13 +13,14 @@ db = use_tinydb("url_pool")
 # and a tiny global kv cache just to prevent duplicate urls
 
 
-def db_add_url(url: str, prompt: str, parent_uuid: str = None):
+def db_add_url(url: str, prompt: str, parent_uuid: str = None, task_uuid: str = None):
     new_uuid = utils.gen_uuid()
     timestamp = utils.gen_unix_time()
 
     new_url_object = {
         "uuid": new_uuid,
         "parent_uuid": parent_uuid,
+        "task_uuid": task_uuid,
         "prompt": prompt,
         "url": url,
         "text": None,

--- a/workers/embedder.py
+++ b/workers/embedder.py
@@ -4,7 +4,7 @@ from colorama import Fore
 from tinydb import Query
 from tinydb.table import Document
 
-from core.databases import db_url_pool, db_embeddings
+from core.databases import db_url_pool, db_embeddings, db_crawl_tasks
 from core.models.configurations import load_llm_config
 from core.tools import utils
 
@@ -27,10 +27,15 @@ def processing_iteration():
     for url_object in embedding_queue:
         print("embedding document:", url_object)
         document = url_object["text"]
+        task_uuid = url_object["task_uuid"]
 
         db_full_name = utils.gen_vec_db_full_name("embeddings", embed_model_name)
+
         db_embeddings.db_add_text_batch(document, db_full_name)
         db_url_pool.db_set_url_embedded(url_object["uuid"], embed_model_name)
+        db_crawl_tasks.db_increment_task_embedding_progression(
+            task_uuid, embed_model_name
+        )
 
     print(f"{Fore.CYAN}Document vectorization completed.{Fore.RESET}")
 

--- a/workers/summarizer.py
+++ b/workers/summarizer.py
@@ -1,5 +1,11 @@
-from core.databases.db_crawl_tasks import db_are_tasks_completed
-from core.databases.db_embeddings import db_search_for_similar_queries
+from core.databases.db_crawl_tasks import (
+    db_are_tasks_completed,
+    db_are_crawl_tasks_fully_embedded,
+)
+from core.databases.db_embeddings import (
+    db_search_for_similar_queries,
+    db_get_currently_used_vector_model,
+)
 from core.databases.db_completion_tasks import (
     db_get_incomplete_completion_tasks,
     db_update_completion_task_after_summarizing,
@@ -41,12 +47,14 @@ def summarize():
     task_queue += db_get_incomplete_completion_tasks(queue_space)
     current_task = task_queue[0]
 
+    current_vec_db_model = db_get_currently_used_vector_model()
+
     # find the first task ready for execution, dismiss the others
     for task in task_queue:
         # check all dependencies for completeness
         dep_list = task["required_crawl_tasks"]
 
-        if db_are_tasks_completed(dep_list):
+        if db_are_crawl_tasks_fully_embedded(dep_list, current_vec_db_model):
             current_task = task
             task_queue.remove(task)
             task_uuid_list = list(map(extract_uuid, task_queue))

--- a/workers/summarizer.py
+++ b/workers/summarizer.py
@@ -45,7 +45,8 @@ def summarize():
 
     queue_space = task_queue_limit - len(task_queue)
     task_queue += db_get_incomplete_completion_tasks(queue_space)
-    current_task = task_queue[0]
+
+    current_task = None
 
     current_vec_db_model = db_get_currently_used_vector_model()
 
@@ -59,6 +60,9 @@ def summarize():
             task_queue.remove(task)
             task_uuid_list = list(map(extract_uuid, task_queue))
             db_release_executing_tasks(task_uuid_list)
+
+    if current_task is None:
+        return
 
     task_query = WebQuery(
         prompt_core=current_task["prompt"], query_type=current_task["mode"].lower()

--- a/workers/summarizer.py
+++ b/workers/summarizer.py
@@ -1,7 +1,9 @@
+from core.databases.db_crawl_tasks import db_are_tasks_completed
 from core.databases.db_embeddings import db_search_for_similar_queries
 from core.databases.db_completion_tasks import (
-    db_get_incomplete_completion_task,
+    db_get_incomplete_completion_tasks,
     db_update_completion_task_after_summarizing,
+    db_release_executing_tasks,
 )
 from langchain_core.runnables import RunnableLambda
 from core.classes.query import WebQuery
@@ -22,38 +24,60 @@ output_parser = StrOutputParser()
 llm, embeddings = load_model()
 
 
+# even though a single task takes a long time to complete,
+# as soon as one task is started, all elements of the queue are released
+task_queue = []
+task_queue_limit = 10
+
+
+def extract_uuid(task):
+    return task["uuid"]
+
+
 def summarize():
+    global task_queue
 
-    task = db_get_incomplete_completion_task()
+    queue_space = task_queue_limit - len(task_queue)
+    task_queue += db_get_incomplete_completion_tasks(queue_space)
+    current_task = task_queue[0]
 
-    if task is None:
-        return
+    # find the first task ready for execution, dismiss the others
+    for task in task_queue:
+        # check all dependencies for completeness
+        dep_list = task["required_crawl_tasks"]
 
-    def get_query():
-        return WebQuery(task["mode"].lower(), prompt_core=task["prompt"])
+        if db_are_tasks_completed(dep_list):
+            current_task = task
+            task_queue.remove(task)
+            task_uuid_list = list(map(extract_uuid, task_queue))
+            db_release_executing_tasks(task_uuid_list)
 
-    context = db_search_for_similar_queries(get_query())
+    task_query = WebQuery(
+        prompt_core=current_task["prompt"], query_type=current_task["mode"].lower()
+    )
+
+    context = db_search_for_similar_queries(task_query)
 
     if context is None:
         return
 
     def interpret_prompt_mode():
-        if task["mode"] == "News":
+        if current_task["mode"] == "News":
             return web_news_lookup_prompt()
-        elif task["mode"] == "Docs":
+        elif current_task["mode"] == "Docs":
             return web_docs_lookup_prompt()
-        elif task["mode"] == "Wiki":
+        elif current_task["mode"] == "Wiki":
             return web_wiki_lookup_prompt()
 
     def get_user_prompt(_: dict):
-        return task["prompt"]
+        return current_task["prompt"]
 
     def get_context(_: dict):
         return context[0].page_content
 
     web_interpret_prompt_mode = interpret_prompt_mode()
 
-    print("Summarizing task with uuid: ", task["uuid"])
+    print("Summarizing task with uuid: ", current_task["uuid"])
     chain = (
         {
             "search_data": RunnableLambda(get_context),
@@ -64,13 +88,21 @@ def summarize():
         | llm
         | output_parser
     )
-    summary = chain.invoke(task)
-    db_update_completion_task_after_summarizing(summary, task["uuid"])
+    summary = chain.invoke(current_task)
+    db_update_completion_task_after_summarizing(summary, current_task["uuid"])
 
-    print(f"{Fore.CYAN}Completed task with uuid: {Fore.RESET}", task["uuid"])
+    print(f"{Fore.CYAN}Completed task with uuid: {Fore.RESET}", current_task["uuid"])
 
 
 previous_queued_tasks = None
+
+# todo: 1. get a list of available tasks, in the backend they'll be automatically set as executing
+#       2. parse through all of them, until one that has all it's dependencies resolved appears
+#       3. once one is found to be ready, release all the other tasks (reset 'executing')
+#       4. proceed with normal execution
+
+# todo: implement class-based task management system
+
 
 while True:
     db = use_tinydb("completion_tasks")


### PR DESCRIPTION
Each crawl task is dispatched either to fill in some gaps in the context used by summary workers, or are dispatched as standalone events when explicitly requested by a user.

Regardless, we want to track the completion level of those tasks, which is not as straightforward, as every single url_object has to be embedded before it's usable.

This PR resolves this issue.